### PR TITLE
Upgrade dependencies to support PHP 8 and Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
-        "laravel/framework": ">=7.0",
+        "php": ">=8.0.0",
+        "laravel/framework": ">=8.0",
         "open-admin-org/open-admin": "~1.0",
-        "ckeditor/ckeditor": "4.21"
+        "ckeditor/ckeditor": "^4.25.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0",
-        "laravel/laravel": "~7.0"
+        "phpunit/phpunit": "~8.0",
+        "laravel/laravel": "~8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated composer.json to require PHP >=8.0 and Laravel >=8.0. Also upgraded CKEditor and PHPUnit to more recent versions to enhance compatibility and maintain security.